### PR TITLE
Trigger documentation via dispatching

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,6 +5,8 @@ on:
     branches:
     - 'master'
   workflow_dispatch:
+  repository_dispatch:
+    types: [build_documentation]
 
 jobs:
   docs:

--- a/.github/workflows/update-sw-distros.yml
+++ b/.github/workflows/update-sw-distros.yml
@@ -48,4 +48,13 @@ jobs:
           git add .
           git commit -m "update SW versioning table to ${SUPERBUILD_TAG}"
           git push
+      - name: Publish Documentation through dispatching
+        env:
+          BOT_TRIGGER_GH_PAGES: ${{ secrets.BOT_TRIGGER_GH_PAGES }}
+        if: env.BOT_TRIGGER_GH_PAGES != null
+        uses: peter-evans/repository-dispatch@v1.1.1
+        with:
+          token: ${{ secrets.BOT_TRIGGER_GH_PAGES }}
+          repository: ${{ github.repository }}
+          event-type: build_documentation
 


### PR DESCRIPTION
This PR allows for automatically triggering the build of gh-pages as a result of a SW distros update.