### PR TITLE
Update SW Distros workflow: use meaningful default for initial_distro

### DIFF
--- a/.github/workflows/update-sw-distros.yml
+++ b/.github/workflows/update-sw-distros.yml
@@ -8,9 +8,9 @@ on:
         required: true
         default: 'master'
       initial_distro:
-        description: 'The initial SW Distro to process e.g. 2020.05'
+        description: 'The initial SW Distro to process e.g. 2020.02'
         required: true
-        default: '0000.00'
+        default: '2020.02'
 
 jobs:
   Update:


### PR DESCRIPTION
I think it is useful to have in `initial_distro`  the initial distro we actually want to use, to reduce the possible human errors.