### PR TITLE
Also configure the NTP support for iCub laptop instructions

### DIFF
--- a/docs/icub_operating_systems/other-machines/generic-machine.md
+++ b/docs/icub_operating_systems/other-machines/generic-machine.md
@@ -174,7 +174,7 @@ Then create the two above mountpoints as follows
 
 # NTP configuration
 
-**NOTE** : skip this step in case of icub server or icub latop
+**NOTE** : skip this step in case of icub server
 
 Edit the file `/etc/ntp.conf` by adding the following line
 


### PR DESCRIPTION
This was something that we noticed with @Iaxama, but I did not put this with https://github.com/icub-tech-iit/documentation/pull/72 as I am not sure on this change, so I would prefer to have @mbrunettini opinion before merging. 

As far as we can see, configuring the laptop to use the NTP server of icub-server could be useful to ensure that icub-head and iCub's laptop use the same time, but perhaps we are missing something. 