### PR TITLE
Enlarge central column

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,5 @@
+@media only screen and (min-width: 76.25em) {
+    .md-main__inner {
+      max-width: none;
+    }
+  }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,9 @@ theme:
   icon:
     logo: material/robot
 
+extra_css:
+  - stylesheets/extra.css
+
 markdown_extensions:
   - markdown.extensions.admonition
   - pymdownx.arithmatex


### PR DESCRIPTION
This PR introduces extra CSS to let the central column be displayed larger than the default width.