### PR TITLE
Enable MathJax

### DIFF
--- a/docs/javascripts/config.js
+++ b/docs/javascripts/config.js
@@ -1,0 +1,17 @@
+window.MathJax = {
+    tex: {
+      inlineMath: [["\\(", "\\)"]],
+      displayMath: [["\\[", "\\]"]],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      ignoreHtmlClass: ".*|",
+      processHtmlClass: "arithmatex"
+    }
+  };
+  
+  document$.subscribe(() => {
+    MathJax.typesetPromise()
+  })
+  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,9 +19,15 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - javascripts/config.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js  
+
 markdown_extensions:
   - markdown.extensions.admonition
-  - pymdownx.arithmatex
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.betterem:
       smart_enable: all
   - pymdownx.caret


### PR DESCRIPTION
This PR enables the use of MathJax as per instructions in https://squidfunk.github.io/mkdocs-material/reference/mathjax.