### PR TITLE
Add study on change of frame

### DIFF
--- a/docs/ft_sensors/change_of_frame_accelerometer.md
+++ b/docs/ft_sensors/change_of_frame_accelerometer.md
@@ -1,0 +1,111 @@
+# Study of change of frame on accelerometer measurements
+Unless noted, notation follows what described in https://pure.tue.nl/ws/portalfiles/portal/139293126/A_Multibody_Dynamics_Notation_Revision_2_.pdf.
+
+#### Author
+
+| | |
+|:---:|:---|
+| [<img src="https://github.com/traversaro.png" width="40">](https://github.com/traversaro) | [@traversaro](https://github.com/traversaro) |
+
+## Problem description
+Assume that we have two accelerometers, that are attached to the same rigid body, but placed in two different frames ($S$ and $B$). 
+We indicate with:
+
+- $A$ the (absolute) inertial frame that we assume to be rigidly attached to the ground (disregarding the rotation of the earth on itself and any other cosmic rotational motion).
+- ${}^A o_B \in \mathbb{R}^3$ the 3D vector that represent the position of the origin of frame $B$ w.r.t. to frame $A$, such that if $S$ is another frame we have:
+
+$$
+\begin{equation}
+{}^A o_S = {}^A o_B + {}^A R_B {}^B o_S. \; (1)
+\end{equation}
+$$
+
+- ${}^A g \in \mathbb{R}^3$ the gravity vector expressed in the inertial frame. 
+- The angular velocity ${}^B \omega_{A,B} \in \mathbb{R}^3$ is defined as:
+
+$$
+\begin{equation}
+{}^B \omega_{A,B} \times = {}^B R_A {}^A \dot{R}_B
+\end{equation}
+$$
+
+from which we can derive that:
+
+$$
+\begin{equation}
+{}^A \dot{R}_B = {}^A R_B {}^B \omega_{A,B} \times
+\end{equation}
+$$
+
+and 
+
+$$
+\begin{align}
+{}^A \ddot{R}_ B &= {}^A \dot{R}_ B {}^B \omega_{A,B} \times + {}^A R_B {}^B \dot{\omega}_{A,B} \times = \\
+&= {}^A R_B {}^B \omega_{A,B} \times {}^B \omega_{A,B} \times + {}^A R_B {}^B \dot{\omega}_{A,B} \times.  \; (2)
+\end{align}
+$$
+
+As $B$ and $S$ are rigidly attached to the same rigid body, we have that ${}^B o_S$ is constant and so:
+
+$$
+\begin{equation}
+{}^B \dot{o}_S = 0. \; (3)
+\end{equation}
+$$
+
+The measure of each sensor is given by:
+
+$$
+\begin{equation}
+m_S = {}^S R_A ( {}^A \ddot{o}_S - {}^A g) \; (4)
+\end{equation}
+$$
+
+$$
+\begin{equation}
+m_B = {}^B R_A ( {}^A \ddot{o}_B - {}^A g) \; (5)
+\end{equation}
+$$
+
+To express $m_S$ in function of $m_B$, we can first take $(1)$ and take first a derivative:
+
+$$
+\begin{equation}
+{}^A \dot{o}_S = {}^A \dot{o}_B + {}^A \dot{R}_B {}^B o_S + {}^A R_B {}^B \dot{o}_S
+\end{equation}
+$$
+
+and then we derivative again:
+
+$$
+\begin{equation}
+{}^A \ddot{o}_S = {}^A \ddot{o}_B + {}^A \ddot{R}_B {}^B o_S + 2 {}^A \dot{R}_B {}^B \dot{o}_S  + {}^A R_B {}^B \ddot{o}_S \; (6)
+\end{equation}
+$$
+
+as we know that the $B$ and $C$ are rigidly attached to the same body (see $(3)$), we have:
+
+$$
+\begin{equation}
+{}^A \ddot{o}_S = {}^A \ddot{o}_B + {}^A \ddot{R}_B {}^B o_S. \; (7)
+\end{equation}
+$$
+
+By substituting $(7)$ in $(4)$ we have:
+
+$$
+\begin{align}
+m_S &= {}^S R_A ( {}^A \ddot{o}_B + {}^A \ddot{R}_B {}^B o_S  - {}^A g) = \\
+&= {}^S R_A ( {}^A \ddot{o}_B - {}^A g)  + {}^S R_A ({}^A \ddot{R}_B {}^B o_S  ) = \\
+&= {}^S R_B m_B + {}^S R_A ({}^A \ddot{R}_B {}^B o_S  )
+\end{align}
+$$
+
+By using $(2)$, we have then:
+
+$$
+\begin{equation}
+m_S = {}^S R_ B ( m_ B + {}^B \omega_{A,B} \times {}^B \omega_{A,B} \times {}^B o_S  + {}^B \dot{\omega}_{A,B} \times  {}^B o_S )
+\end{equation}.
+$$

--- a/docs/ft_sensors/change_of_frame_accelerometer.md
+++ b/docs/ft_sensors/change_of_frame_accelerometer.md
@@ -1,5 +1,5 @@
 # Study of change of frame on accelerometer measurements
-Unless noted, notation follows what described in https://pure.tue.nl/ws/portalfiles/portal/139293126/A_Multibody_Dynamics_Notation_Revision_2_.pdf.
+Unless noted, notation follows what is described in ["A Multibody Dynamics Notation – Revision_2"](https://pure.tue.nl/ws/portalfiles/portal/139293126/A_Multibody_Dynamics_Notation_Revision_2_.pdf) 📚
 
 #### Author
 

--- a/docs/ft_sensors/index.md
+++ b/docs/ft_sensors/index.md
@@ -1,0 +1,7 @@
+## F/T Sensors
+
+### [Overview of F/T sensors](./ft_sensors.md)
+
+### [The onboard IMU device](./onboard_imu.md)
+
+### [Study on change of frame for accelerometer measurements](./change_of_frame_accelerometer.md)

--- a/docs/ft_sensors/onboard_imu.md
+++ b/docs/ft_sensors/onboard_imu.md
@@ -60,8 +60,9 @@ $$
 m_S = {}^S R_ B ( m_ B + {}^B \omega_{A,B} \times {}^B \omega_{A,B} \times {}^B o_S  + {}^B \dot{\omega}_{A,B} \times  {}^B o_S ),
 $$
 
-where the last two terms on the right are the non-inertial terms that appear in the reference frame transformation. The suffix *A* means that the quantity is 
-calculated w.r.t. the inertial *absolute* reference frame. 
+where the last two terms on the right are the non-inertial terms that appear in the reference frame transformation. The suffix *A* means that the quantity is calculated w.r.t. the inertial *absolute* reference frame. 
+
+For a more thorough and complete analysis, refer to this [study](./change_of_frame_accelerometer.md) 📚
 
 ### Measurement of non-inertial terms in realistic scenarios
 To assess the required level of precision in transforming the acceleration between the two dragged reference frames, we performed a few tests in a real world case, i.e. 
@@ -126,7 +127,7 @@ bool embot::app::application::theIMU::Impl::fill(embot::prot::can::inertial::per
 
 The same applies to the corresponding gyroscope data. 
 
-**Notice how the preprocessor condition aimed to guarantee the correct behaviour for other boards using a BNO055 IMU** preventing unwanted behaviors. 
+**Notice how the preprocessor condition aimed to guarantee the correct behaviour for other boards using the BNO055 IMU device**.
 
 ## Outlook
 As a future step, we may consider implementing the full transformation that includes the non-intertial terms. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,8 +95,10 @@ nav:
         - KIT_006 Update of differential neck pulley: upgrade_kits/differential_neck_pulley/support.md
         - KIT_007 Ankle for climbing stairs : upgrade_kits/ankle_for_stairs/support.md
       - F/T Sensors:
+        - Summary: ft_sensors/index.md
         - F/T Sensors: ft_sensors/ft_sensors.md
-        - F/T Sensors IMU: ft_sensors/ft_sensors_imu.md
+        - Onboard IMU: ft_sensors/onboard_imu.md
+        - Study on change of frame for accelerometer measurements: ft_sensors/change_of_frame_accelerometer.md
       - iCub Kinematics:
         - Summary: icub_kinematics/index.md
         - iCub Joints: icub_kinematics/icub-joints/icub-joints.md


### PR DESCRIPTION
This PR integrates #105 with the [study][1] done by @traversaro on the change of frame for the accelerometer measurements.

This was made possible thanks to the MathJax plugin introduced in #107.

[1]: http://mathb.in/50168