### PR TITLE
Fixed back quote in public key

### DIFF
--- a/docs/sw_installation/linux_binaries.md
+++ b/docs/sw_installation/linux_binaries.md
@@ -24,7 +24,7 @@ sudo apt update
 Import the repository public key (this needs to be done only once)
 
 ~~~
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 57A5ACB6110576A6`
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 57A5ACB6110576A6
 ~~~
 
 ### Dependencies


### PR DESCRIPTION
A back quote was present in the line associated to the public key, causing potential errors when copy pasting.