### PR TITLE
Clarify steps after installation on icub-head from pre-built image

### DIFF
--- a/docs/icub_operating_systems/icubos/installation-from-image.md
+++ b/docs/icub_operating_systems/icubos/installation-from-image.md
@@ -66,4 +66,8 @@ Power down the icub-head and unplug the USB hub, then restart.
 
 ## Customize the system
 
-What now you need to do is to customize the installation with your hardware and enviroment (see the "_Required configuration_" paragraph in [_Networking_](networking.md) and [_Bluetooth_](bluetooth.md) chapters)
+What now you need to do is to customize the installation with your hardware and enviroment, in particular see the "_Required configuration_" section in [_Networking_](networking.md).
+
+If you need to connect the icub-head to any Bluetooth device, please check the steps described in [_Bluetooth_](bluetooth.md).
+
+After you correctly setup your network, you can proceed in installing the required YARP and iCub software by following the guide on [Superbuild installation on icub-head](../../sw_installation/icub_head_superbuild.md).


### PR DESCRIPTION
I recently installed a iCubOS 8 image (based on Ubuntu 20.04) and talking with @davidelasagna it turned out that the Bluetooth option is not strictly necessary, so I modified the link to clarify that. Furthermore, I also added a link to the documentaiton on how to install YARP/iCub software, as this is the natural following step after you installed a new image.