### PR TITLE
Distro naming convention relies on patch number

### DIFF
--- a/scripts/sw-distros/template_index.md
+++ b/scripts/sw-distros/template_index.md
@@ -8,7 +8,7 @@ Software Distros
 - 📛 Naming convention adheres therefore to **`YYYY.MM.0`**, where **`YYYY`** identifies the year so as **`MM`** the month of the distro. The patch number **`0`** clarifies that it is a major distro. Examples: 2021.11.0, 2022.02.0...
 - 📝 Repositories stay on their usual release convention in order to enable proper **semantic versioning**. To link repos tags to SW Distro and run CI, we rely on the infrastructure provided in [`robotology/robotology-superbuild`](https://github.com/robotology/robotology-superbuild).
 - 📦 Occasionally, we may release **feature-based distros** and/or **patches** as a collection of tags/branches (i.e., no binaries). Naming convention follows the pattern **`YYYY.MM.P`**, where **`YYYY.MM`** identifies the major release used as baseline and the patch number **`P`** is simply increased also in the case of a feature or patch distro released after YYYY/MM.
-- ⚠ Distros released before `2021.11.00` may lack the patch number **`P`**.
+- ⚠ Distros released before `2021.11.00` may be named without the patch number **`P`** and may also be marked explicitly with `feat` or `patch` labels. 
 - 📢 We make **announcements** of the distros and their content on a dedicated channel of [Robotology Community](https://github.com/robotology/community/discussions/categories/releases).
 
 ## Software Versioning Table

--- a/scripts/sw-distros/template_index.md
+++ b/scripts/sw-distros/template_index.md
@@ -8,7 +8,7 @@ Software Distros
 - 📛 Naming convention adheres therefore to **`YYYY.MM.0`**, where **`YYYY`** identifies the year so as **`MM`** the month of the distro. The patch number **`0`** clarifies that it is a major distro. Examples: 2021.11.0, 2022.02.0...
 - 📝 Repositories stay on their usual release convention in order to enable proper **semantic versioning**. To link repos tags to SW Distro and run CI, we rely on the infrastructure provided in [`robotology/robotology-superbuild`](https://github.com/robotology/robotology-superbuild).
 - 📦 Occasionally, we may release **feature-based distros** and/or **patches** as a collection of tags/branches (i.e., no binaries). Naming convention follows the pattern **`YYYY.MM.P`**, where **`YYYY.MM`** identifies the major release used as baseline and the patch number **`P`** is simply increased also in the case of a feature or patch distro released after YYYY/MM.
-- ⚠ Distros released before `2021.11.00` may be named without the patch number **`P`** and may also be marked explicitly with `feat` or `patch` labels. 
+- ⚠ Distros released before `2021.11.0` may be named without the patch number **`P`** and may also be marked explicitly with `feat` or `patch` labels. 
 - 📢 We make **announcements** of the distros and their content on a dedicated channel of [Robotology Community](https://github.com/robotology/community/discussions/categories/releases).
 
 ## Software Versioning Table

--- a/scripts/sw-distros/template_index.md
+++ b/scripts/sw-distros/template_index.md
@@ -2,13 +2,13 @@ Software Distros
 ===
 
 ## 🚀 Software Distros Workflow
-- 📅 SW Distros are delivered on a **time-based workflow**.
-- 4️⃣ SW Distros are released along with **binaries** at the following quarters: **Feb, May, Aug, Nov**.
+- 📅 SW Distros are typically delivered on a **time-based workflow**.
+- 4️⃣ SW Distros are usually released along with **binaries** at the following quarters: **Feb, May, Aug, Nov**.
 - 🆓 The feature-freeze lasts **one month**.
-- 📛 Naming convention adheres therefore to **YYYY.MM**: e.g. 2020.02, 2020.05...
+- 📛 Naming convention adheres therefore to **`YYYY.MM.0`**, where **`YYYY`** identifies the year so as **`MM`** the month of the distro. The patch number **`0`** clarifies that it is a major distro. Examples: 2021.11.0, 2022.02.0...
 - 📝 Repositories stay on their usual release convention in order to enable proper **semantic versioning**. To link repos tags to SW Distro and run CI, we rely on the infrastructure provided in [`robotology/robotology-superbuild`](https://github.com/robotology/robotology-superbuild).
-- 📦 Occasionally, we may deliver **feature-based releases** (only tags/branches, no binaries) as **YYYY.MM.feat-nn**.
-- 🐞 **Patches** are coded as **YYYY.MM.patch-nn** and, like the feature-based releases, are shipped only in terms of tags/branches.
+- 📦 Occasionally, we may release **feature-based distros** and/or **patches** as a collection of tags/branches (i.e., no binaries). Naming convention follows the pattern **`YYYY.MM.P`**, where **`YYYY.MM`** identifies the major release used as baseline and the patch number **`P`** is simply increased also in the case of a feature or patch distro released after YYYY/MM.
+- ⚠ Distros released before `2021.11.00` may lack the patch number **`P`**.
 - 📢 We make **announcements** of the distros and their content on a dedicated channel of [Robotology Community](https://github.com/robotology/community/discussions/categories/releases).
 
 ## Software Versioning Table


### PR DESCRIPTION
This is a possible variation of the explanation of our distro workflow following up on @traversaro 's proposal.