### PR TITLE
ssh-copy-id between icubsrv and icubsrv itself

### DIFF
--- a/docs/icub_operating_systems/other-machines/icub-server-laptop.md
+++ b/docs/icub_operating_systems/other-machines/icub-server-laptop.md
@@ -156,6 +156,12 @@ Upload this key file to icub-head
 ssh-copy-id -i /home/icub/.ssh/id_rsa.pub icub@icub-head
 ```
 
+You have to create a ssh connection also between icubsrv and icubsrv itself in order to let yarp run as server automatically through yarpmanager:
+
+```
+ssh-copy-id -i /home/icub/.ssh/id_rsa.pub icub@icubsrv
+```
+
 ## Other configurations
 
 ## IP forwarding and NAT


### PR DESCRIPTION
Following the installation procedure and without this step it is impossible to start yarpserver from yarpmanager GUI (keeps asking for the password on the terminal).