### PR TITLE
Fix instruction on installing http://www.icub.org/ubuntu repo on iCubOS

### DIFF
--- a/docs/icub_operating_systems/icubos/installation-from-scratch.md
+++ b/docs/icub_operating_systems/icubos/installation-from-scratch.md
@@ -77,8 +77,9 @@ sudo systemctl disable gdm
 
 2. Edit as follows
   ```
-  deb http://www.icub.org/ubuntu xenial contrib/science
+  deb http://www.icub.org/ubuntu focal contrib/science
   ```
+  Where you can substitute `focal` with the codename of the distribution that you are using. 
 
 3. Import the icub SSH key
   ```


### PR DESCRIPTION
Since https://github.com/icub-tech-iit/documentation/pull/84 the documentation was targeting Ubuntu 20.04 (focal), but this specific step was still targeting Xenial (16.04). I changed it to target focal, with an additional sentence to avoid to create problems even if in the future we do not update it again.