### PR TITLE
Fix elbow joint name in hand mk5

### DIFF
--- a/docs/hands/hands_mk5.md
+++ b/docs/hands/hands_mk5.md
@@ -2,7 +2,7 @@
 
 | Joint number  | Motors | Identifier    | Type | Parent link        | Child link         | Notes           |
 |---------------|--------|---------------|------|--------------------|--------------------|-----------------|
-|               |        | l_elbow_pitch |  ROT | l_upperarm         | l_forearm          | E1 in figure    |
+|               |        | l_elbow       |  ROT | l_upperarm         | l_forearm          | E1 in figure    |
 |               |        | l_wrist_yaw   |  ROT | l_forearm          | l_wrist_1          | W1 in fig.      |
 |               |        | l_wrist_roll  |  ROT | l_wrist_1          | l_wrist_2          | W2 in fig.      |
 |               |        | l_wrist_pitch |  ROT | l_wrist_2          | l_hand_palm        | W3 in fig.      |


### PR DESCRIPTION
For more backward compatibility and since in the elbow we have just one joint I would remove the `_pitch` suffix

(in `ergoCub` urdfs is already like that)

cc @pattacini @Lawproto @salvi-mattia @Mick3Lozzo @fiorisi @traversaro @mfussi66 