### PR TITLE
Add sensor tables for robots

### DIFF
--- a/docs/robot_sensors/ergocub_sensors.md
+++ b/docs/robot_sensors/ergocub_sensors.md
@@ -1,13 +1,14 @@
 # Sensors mounted on ergoCub
+
 This page lists all the sensors mounted on ergoCub, and how to access their information.
 
 ## Head
 
 |Type |Sensor Name| Device | YARP Port | Data pattern | Publish rate (Hz) |
-| --- | --- | --- | --- | --- | --- | 
+| --- | --- | --- | --- | --- | --- |
 |**ControlBoard** | `head` | MC4PLUS | `/ergocub/head/state:o` | (joint_encoders) | 100 |
 | - | - | - | `/ergocub/head/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-|**IMU** | `head/imu` | RFE board, Bosch BNO055 IMU | `/ergocub/head/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `head/imu` | RFE, BNO055 | `/ergocub/head/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 |**Depth Camera** | `depthCamera` | Intel Realsense D450 | `/ergocub/depthCamera/rgbImage:o` | ( (R channel)  (G channel)  (B channel) ) | 30 |
 | - | - | - | `/ergocub/depthCamera/depthImage:o` | (depth_pixels_list) | 30 |
 |**Lidar** | `laser` | Slamtec RP Lidar S2 | `/ergocub/laser:o` | Defined in [LaserScan2D.thrift](https://github.com/robotology/yarp/blob/2d3aacc1493b9f1813afecbc1a272f21f358915d/src/libYARP_dev/src/idl/LaserScan2D.thrift#L15-L34) | 100 |
@@ -18,40 +19,45 @@ This page lists all the sensors mounted on ergoCub, and how to access their info
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `torso` | EMS+2FOC | `/ergocub/torso/state:o` | (joint_encoders) | 100|
 | - | - | - | `/ergocub/torso/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
-| **Battery** | `batttery` | BMS | `/ergocub/battery` | (voltage current charge temperature status) | 1 |
+| **Battery** | `battery` | BMS | `/ergocub/battery` | (voltage current charge temperature status) | 1 |
+| IMU | `waist/inertials` | XSense MTi-600 | `/ergocub/waist/inertials/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+
 ## Left Arm
+
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `left_arm` | EMS+2FOC, MC4PLUS, AMC+AMCBLDC | `/ergocub/left_arm/state:o` | (joint_encoders) | 100|
 | - | - | - | `/ergocub/left_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 |**Force-Torque Sensor** | `left_arm/FT` | FT45 | `/ergocub/left_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
-|**IMU** | `left_arm/imu` | Bosch BNO055 | `/ergocub/left_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-| - | `left_arm/inertialMTB` | MTB4 board, Bosch BNO055 | `/ergocub/left_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `left_arm/imu` | STRAIN2, BNO055 | `/ergocub/left_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| - | `left_arm/inertialMTB` | MTB4, BNO055 | `/ergocub/left_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 
 ## Right Arm
+
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `right_arm` | EMS+2FOC, MC4PLUS, AMC+AMCBLDC | `/ergocub/right_arm/state:o` | (joint_encoders) | 100|
 | - | - | - | `/ergocub/right_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 |**Force-Torque Sensor** | `right_arm/FT` | FT45 | `/ergocub/right_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
-|**IMU** | `right_arm/imu` | Bosch BNO055 | `/ergocub/right_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-| - | `right_arm/inertialMTB` | MTB4 board, Bosch BNO055 | `/ergocub/right_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `right_arm/imu` | STRAIN2, BNO055 | `/ergocub/right_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| - | `right_arm/inertialMTB` | MTB4, BNO055 | `/ergocub/right_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 
 ## Left Leg
+
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `left_leg` | EMS+2FOC | `/ergocub/left_leg/state:o` | (joint_encoders) | 100|
 | - | - | - | `/ergocub/left_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 |**Force-Torque Sensors** | `left_leg/FT` | FT45, FT58 | `/ergocub/left_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
-|**IMU** | `left_leg/imu` | Bosch BNO055 | `/ergocub/left_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-| -  | `left_foot_heel_tiptoe/imu ` | Bosch BNO055 | `/ergocub/left_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-
+|**IMU** | `left_leg/imu` | STRAIN2, BNO055 | `/ergocub/left_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `left_foot_heel_tiptoe/imu` | STRAIN2, BNO055 | `/ergocub/left_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 
 ## Right Leg
+
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `right_leg` | EMS+2FOC | `/ergocub/right_leg/state:o` | (joint_encoders) | 100|
 | - | - | - | `/ergocub/right_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 |**Force-Torque Sensors** | `right_leg/FT` | FT45, FT58 | `/ergocub/right_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
-|**IMU** | `right_leg/imu` | Bosch BNO055 | `/ergocub/right_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-| -  | `right_foot_heel_tiptoe/imu ` | Bosch BNO055 | `/ergocub/right_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `right_leg/imu` | STRAIN2, BNO055 | `/ergocub/right_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `right_foot_heel_tiptoe/imu` | STRAIN2, BNO055 | `/ergocub/right_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |

--- a/docs/robot_sensors/ergocub_sensors.md
+++ b/docs/robot_sensors/ergocub_sensors.md
@@ -1,2 +1,57 @@
 # Sensors mounted on ergoCub
 This page lists all the sensors mounted on ergoCub, and how to access their information.
+
+## Head
+
+|Type |Sensor Name| Device | YARP Port | Data pattern | Publish rate (Hz) |
+| --- | --- | --- | --- | --- | --- | 
+|**ControlBoard** | `head` | MC4PLUS | `/ergocub/head/state:o` | (joint_encoders) | 100 |
+| - | - | - | `/ergocub/head/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `head/imu` | RFE board, Bosch BNO055 IMU | `/ergocub/head/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**Depth Camera** | `depthCamera` | Intel Realsense D450 | `/ergocub/depthCamera/rgbImage:o` | ( (R channel)  (G channel)  (B channel) ) | 30 |
+| - | - | - | `/ergocub/depthCamera/depthImage:o` | (depth_pixels_list) | 30 |
+|**Lidar** | `laser` | Slamtec RP Lidar S2 | `/ergocub/laser:o` | Defined in [LaserScan2D.thrift](https://github.com/robotology/yarp/blob/2d3aacc1493b9f1813afecbc1a272f21f358915d/src/libYARP_dev/src/idl/LaserScan2D.thrift#L15-L34) | 100 |
+
+## Torso
+
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `torso` | EMS+2FOC | `/ergocub/torso/state:o` | (joint_encoders) | 100|
+| - | - | - | `/ergocub/torso/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+| **Battery** | `batttery` | BAT | `/ergocub/battery` | (voltage current charge temperature status) | 1 |
+## Left Arm
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `left_arm` | EMS+2FOC, MC4PLUS, AMC+AMCBLDC | `/ergocub/left_arm/state:o` | (joint_encoders) | 100|
+| - | - | - | `/ergocub/left_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensor** | `left_arm/FT` | FT45 | `/ergocub/left_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `left_arm/imu` | Bosch BNO055 | `/ergocub/left_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| - | `left_arm/inertialMTB` | MTB4 board, Bosch BNO055 | `/ergocub/left_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+
+## Right Arm
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `right_arm` | EMS+2FOC, MC4PLUS, AMC+AMCBLDC | `/ergocub/right_arm/state:o` | (joint_encoders) | 100|
+| - | - | - | `/ergocub/right_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensor** | `right_arm/FT` | FT45 | `/ergocub/right_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `right_arm/imu` | Bosch BNO055 | `/ergocub/right_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| - | `right_arm/inertialMTB` | MTB4 board, Bosch BNO055 | `/ergocub/right_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+
+## Left Leg
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `left_leg` | EMS+2FOC | `/ergocub/left_leg/state:o` | (joint_encoders) | 100|
+| - | - | - | `/ergocub/left_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensors** | `left_leg/FT` | FT45, FT58 | `/ergocub/left_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `left_leg/imu` | Bosch BNO055 | `/ergocub/left_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `left_foot_heel_tiptoe/imu ` | Bosch BNO055 | `/ergocub/left_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+
+
+## Right Leg
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `right_leg` | EMS+2FOC | `/ergocub/right_leg/state:o` | (joint_encoders) | 100|
+| - | - | - | `/ergocub/right_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensors** | `right_leg/FT` | FT45, FT58 | `/ergocub/right_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `right_leg/imu` | Bosch BNO055 | `/ergocub/right_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `right_foot_heel_tiptoe/imu ` | Bosch BNO055 | `/ergocub/right_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |

--- a/docs/robot_sensors/ergocub_sensors.md
+++ b/docs/robot_sensors/ergocub_sensors.md
@@ -18,7 +18,7 @@ This page lists all the sensors mounted on ergoCub, and how to access their info
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `torso` | EMS+2FOC | `/ergocub/torso/state:o` | (joint_encoders) | 100|
 | - | - | - | `/ergocub/torso/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
-| **Battery** | `batttery` | BAT | `/ergocub/battery` | (voltage current charge temperature status) | 1 |
+| **Battery** | `batttery` | BMS | `/ergocub/battery` | (voltage current charge temperature status) | 1 |
 ## Left Arm
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/robot_sensors/ergocub_sensors.md
+++ b/docs/robot_sensors/ergocub_sensors.md
@@ -20,7 +20,7 @@ This page lists all the sensors mounted on ergoCub, and how to access their info
 |**ControlBoards** | `torso` | EMS+2FOC | `/ergocub/torso/state:o` | (joint_encoders) | 100|
 | - | - | - | `/ergocub/torso/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 | **Battery** | `battery` | BMS | `/ergocub/battery` | (voltage current charge temperature status) | 1 |
-| IMU | `waist/inertials` | XSense MTi-600 | `/ergocub/waist/inertials/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| **IMU** | `waist/inertials` | XSense MTi-600 | `/ergocub/waist/inertials/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 
 ## Left Arm
 

--- a/docs/robot_sensors/icub2.7_sensors.md
+++ b/docs/robot_sensors/icub2.7_sensors.md
@@ -1,2 +1,63 @@
 # Sensors mounted on iCub 2.7
+
 This page lists all the sensors mounted on iCub 2.7, and how to access their information.
+
+## Head
+
+|Type |Sensor Name| Device | YARP Port | Data pattern | Publish rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoard** | `head` | MC4PLUS | `/icub/head/state:o` | (joint_encoders) | 100 |
+| - | - | - | `/icub/head/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**ControlBoard** | `face` | MC4PLUS | `/icub/face/state:o` | (joint_encoders) | 100 |
+| - | - | - | `/icub/face/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `head/inertials` | RFE, BNO055 | `/icub/head/inertials/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**Eyes cameras** | `head/cam` | Dragonfly | `/icub/head/cam/left` | ( (R channel)  (G channel)  (B channel) ) | 30 |
+| - | - | - | `/icub/head/cam/right` | ( (R channel)  (G channel)  (B channel) ) | 30 |
+
+## Torso
+
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `torso` | EMS+2FOC | `/icub/torso/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/torso/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**IMU** | `waist/inertials` | MTB, BNO055 | `/icub/waist/inertials/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+
+## Left Arm
+
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `left_arm` | EMS+2FOC, MC4PLUS | `/icub/left_arm/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/left_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensor** | `left_arm/FT` | FT45 | `/icub/left_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `left_arm/inertials` | STRAIN2, BNO055 | `/icub/left_arm/inertials/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**Skin** | `left_hand` | MAIS | `/icub/left_hand/analog:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+
+## Right Arm
+
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `right_arm` | EMS+2FOC, MC4PLUS | `/icub/right_arm/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/right_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensor** | `right_arm/FT` | FT45 | `/icub/right_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `right_arm/inertials` | STRAIN2, BNO055 | `/icub/right_arm/inertials/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**Skin** | `right_hand` | MAIS | `/icub/right_hand/analog:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+
+## Left Leg
+
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `left_leg` | EMS+2FOC | `/icub/left_leg/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/left_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensors** | `left_leg/FT` | FT45 | `/icub/left_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `left_leg/imu` |STRAIN2, BNO055 | `/icub/left_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `left_foot/imu` | STRAIN2, BNO055 | `/icub/left_foot/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+
+## Right Leg
+
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `right_leg` | EMS+2FOC | `/icub/right_leg/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/right_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensors** | `right_leg/FT` | FT45 | `/icub/right_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `right_leg/imu` | STRAIN2, BNO055 | `/icub/right_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `right_foot/imu` | STRAIN2, BNO055 | `/icub/right_foot/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |

--- a/docs/robot_sensors/icub3_sensors.md
+++ b/docs/robot_sensors/icub3_sensors.md
@@ -8,7 +8,7 @@ This page lists all the sensors mounted on iCub 3, and how to access their infor
 |**ControlBoard** | `head` | MC4PLUS | `/icub/head/state:o` | (joint_encoders) | 100 |
 | - | - | - | `/icub/head/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 |**IMU** | `head/imu` | RFE board, Bosch BNO055 IMU | `/icub/head/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-|**Eyes cameras** | `head/cam` | Basler | `/icub/head/cam/left` | ( (R channel)  (G channel)  (B channel) ) | 30 |
+|**Eyes cameras** | `head/cam` | Basler daA4200-30mci | `/icub/head/cam/left` | ( (R channel)  (G channel)  (B channel) ) | 30 |
 | - | - | - | `/icub/head/cam/right` | ( (R channel)  (G channel)  (B channel) ) | 30 |
 
 ## Torso
@@ -17,7 +17,7 @@ This page lists all the sensors mounted on iCub 3, and how to access their infor
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `torso` | EMS+2FOC | `/icub/torso/state:o` | (joint_encoders) | 100|
 | - | - | - | `/icub/torso/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
-| **Battery** | `batttery` | BAT | `/icub/battery` | | 1 |
+| **Battery** | `batttery` | BMS | `/icub/battery` | | 1 |
 ## Left Arm
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/robot_sensors/icub3_sensors.md
+++ b/docs/robot_sensors/icub3_sensors.md
@@ -1,13 +1,14 @@
 # Sensors mounted on iCub 3
+
 This page lists all the sensors mounted on iCub 3, and how to access their information.
 
 ## Head
 
 |Type |Sensor Name| Device | YARP Port | Data pattern | Publish rate (Hz) |
-| --- | --- | --- | --- | --- | --- | 
+| --- | --- | --- | --- | --- | --- |
 |**ControlBoard** | `head` | MC4PLUS | `/icub/head/state:o` | (joint_encoders) | 100 |
 | - | - | - | `/icub/head/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-|**IMU** | `head/imu` | RFE board, Bosch BNO055 IMU | `/icub/head/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `head/imu` | RFE, BNO055 | `/icub/head/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 |**Eyes cameras** | `head/cam` | Basler daA4200-30mci | `/icub/head/cam/left` | ( (R channel)  (G channel)  (B channel) ) | 30 |
 | - | - | - | `/icub/head/cam/right` | ( (R channel)  (G channel)  (B channel) ) | 30 |
 
@@ -18,40 +19,43 @@ This page lists all the sensors mounted on iCub 3, and how to access their infor
 |**ControlBoards** | `torso` | EMS+2FOC | `/icub/torso/state:o` | (joint_encoders) | 100|
 | - | - | - | `/icub/torso/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 | **Battery** | `batttery` | BMS | `/icub/battery` | | 1 |
+
 ## Left Arm
+
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `left_arm` | EMS+2FOC, MC4PLUS | `/icub/left_arm/state:o` | (joint_encoders) | 100|
 | - | - | - | `/icub/left_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 |**Force-Torque Sensor** | `left_arm/FT` | FT45 | `/icub/left_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
-|**IMU** | `left_arm/imu` | Bosch BNO055 | `/icub/left_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-| - | `left_arm/inertialMTB` | MTB4 board, Bosch BNO055 | `/icub/left_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `left_arm/imu` | STRAIN2, BNO055 | `/icub/left_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| - | `left_arm/inertialMTB` | MTB4, BNO055 | `/icub/left_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 
 ## Right Arm
+
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `right_arm` | EMS+2FOC, MC4PLUS | `/icub/right_arm/state:o` | (joint_encoders) | 100|
 | - | - | - | `/icub/right_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 |**Force-Torque Sensor** | `right_arm/FT` | FT45 | `/icub/right_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
-|**IMU** | `right_arm/imu` | Bosch BNO055 | `/icub/right_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-| - | `right_arm/inertialMTB` | MTB4 board, Bosch BNO055 | `/icub/right_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `right_arm/imu` | STRAIN2, BNO055 | `/icub/right_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| - | `right_arm/inertialMTB` | MTB4, BNO055 | `/icub/right_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 
 ## Left Leg
+
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `left_leg` | EMS+2FOC | `/icub/left_leg/state:o` | (joint_encoders) | 100|
 | - | - | - | `/icub/left_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 |**Force-Torque Sensors** | `left_leg/FT` | FT45, FT58 | `/icub/left_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
-|**IMU** | `left_leg/imu` | Bosch BNO055 | `/icub/left_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-| -  | `left_foot_heel_tiptoe/imu ` | Bosch BNO055 | `/icub/left_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-
+|**IMU** | `left_leg/imu` | STRAIN2, BNO055 | `/icub/left_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `left_foot_heel_tiptoe/imu` | STRAIN2, BNO055 | `/icub/left_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
 
 ## Right Leg
+
 |Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
 | --- | --- | --- | --- | --- | --- |
 |**ControlBoards** | `right_leg` | EMS+2FOC | `/icub/right_leg/state:o` | (joint_encoders) | 100|
 | - | - | - | `/icub/right_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
 |**Force-Torque Sensors** | `right_leg/FT` | FT45, FT58 | `/icub/right_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
-|**IMU** | `right_leg/imu` | Bosch BNO055 | `/icub/right_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-| -  | `right_foot_heel_tiptoe/imu ` | Bosch BNO055 | `/icub/right_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
-
+|**IMU** | `right_leg/imu` | STRAIN2, BNO055 | `/icub/right_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `right_foot_heel_tiptoe/imu` | STRAIN2, BNO055 | `/icub/right_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |

--- a/docs/robot_sensors/icub3_sensors.md
+++ b/docs/robot_sensors/icub3_sensors.md
@@ -1,2 +1,57 @@
 # Sensors mounted on iCub 3
 This page lists all the sensors mounted on iCub 3, and how to access their information.
+
+## Head
+
+|Type |Sensor Name| Device | YARP Port | Data pattern | Publish rate (Hz) |
+| --- | --- | --- | --- | --- | --- | 
+|**ControlBoard** | `head` | MC4PLUS | `/icub/head/state:o` | (joint_encoders) | 100 |
+| - | - | - | `/icub/head/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**IMU** | `head/imu` | RFE board, Bosch BNO055 IMU | `/icub/head/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+|**Eyes cameras** | `head/cam` | Basler | `/icub/head/cam/left` | ( (R channel)  (G channel)  (B channel) ) | 30 |
+| - | - | - | `/icub/head/cam/right` | ( (R channel)  (G channel)  (B channel) ) | 30 |
+
+## Torso
+
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `torso` | EMS+2FOC | `/icub/torso/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/torso/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+| **Battery** | `batttery` | BAT | `/icub/battery` | | 1 |
+## Left Arm
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `left_arm` | EMS+2FOC, MC4PLUS | `/icub/left_arm/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/left_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensor** | `left_arm/FT` | FT45 | `/icub/left_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `left_arm/imu` | Bosch BNO055 | `/icub/left_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| - | `left_arm/inertialMTB` | MTB4 board, Bosch BNO055 | `/icub/left_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+
+## Right Arm
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `right_arm` | EMS+2FOC, MC4PLUS | `/icub/right_arm/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/right_arm/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensor** | `right_arm/FT` | FT45 | `/icub/right_arm/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `right_arm/imu` | Bosch BNO055 | `/icub/right_arm/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| - | `right_arm/inertialMTB` | MTB4 board, Bosch BNO055 | `/icub/right_arm/inertialMTB/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+
+## Left Leg
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `left_leg` | EMS+2FOC | `/icub/left_leg/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/left_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensors** | `left_leg/FT` | FT45, FT58 | `/icub/left_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `left_leg/imu` | Bosch BNO055 | `/icub/left_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `left_foot_heel_tiptoe/imu ` | Bosch BNO055 | `/icub/left_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+
+
+## Right Leg
+|Type |Sensor name| Device | YARP Port |Data pattern | Publish Rate (Hz) |
+| --- | --- | --- | --- | --- | --- |
+|**ControlBoards** | `right_leg` | EMS+2FOC | `/icub/right_leg/state:o` | (joint_encoders) | 100|
+| - | - | - | `/icub/right_leg/stateExt:o` | Defined in [stateExt.thrift](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/src/idl/stateExt.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100|
+|**Force-Torque Sensors** | `right_leg/FT` | FT45, FT58 | `/icub/right_leg/FT/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?) |100|
+|**IMU** | `right_leg/imu` | Bosch BNO055 | `/icub/right_leg/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+| -  | `right_foot_heel_tiptoe/imu ` | Bosch BNO055 | `/icub/right_foot_heel_tiptoe/imu/measures:o` | Defined in  [multipleAnalogSensorsSerializations.thrift](https://github.com/robotology/yarp/blob/master/src/devices/multipleAnalogSensorsMsgs/multipleAnalogSensorsSerializations.thrift?rgh-link-date=2023-05-10T12%3A50%3A28Z) | 100 |
+

--- a/docs/robot_sensors/index.md
+++ b/docs/robot_sensors/index.md
@@ -1,9 +1,10 @@
 # Sensors mounted on the iCub family of robots
-This page provides information on how to  data streamed by the sensors and devices mounted on the robots. The snesors includ cameras, force-torque sensors, controlboards, and many more.
+
+This page provides information on how to access data streamed by the sensors and devices mounted on the robots. The sensors include cameras, force-torque sensors, controlboards, and many more.
 
 For details on the types of sensors and interfaces available see the [YARP Network Wrapper Server convention](./yarp_nws_convention.md).
 
-## List of sensors for each robot
+## Table of sensors for each robot
 
 - [iCub 2.7](./icub2.7_sensors.md)
 - [iCub 3](./icub3_sensors.md)


### PR DESCRIPTION
This PR is a first attempt at documenting all the sensor interfaces available on the robots iCub2.7, iCub3, ergoCub.

There is a page for each robot, with tables for each robot part. The rows contain info about the sensor involved, and which port to use with YARP to access the data.

To browse the documentation in my fork, you can use this Gitpod snapshot: https://gitpod.io/new/#snapshot/5e5df273-9670-4e69-8546-e36a27cdf7e5 .

Just do a `mkdocs serve` in the VSCode terminal, and click on the link to be redirected to the rendered doc page.