### PR TITLE
Use mkdocs@v1.5.0

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,9 +23,10 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-wheel python3-setuptools
-          pip3 install --upgrade Jinja2
-          pip3 install --user mkdocs mkdocs-material pymdown-extensions
-          pip3 install --upgrade pygments
+          pip install --upgrade Jinja2
+          pip install --user mkdocs
+          pip install --user $(mkdocs get-deps)
+          pip install --upgrade pygments
           echo "${HOME}/.local/bin" >> ${GITHUB_PATH}
         
       - name: Configure Git

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -14,9 +14,10 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-wheel python3-setuptools
-          pip3 install --upgrade Jinja2
-          pip3 install --user mkdocs mkdocs-material pymdown-extensions
-          pip3 install --upgrade pygments
+          pip install --upgrade Jinja2
+          pip install --user mkdocs
+          pip install --user $(mkdocs get-deps)
+          pip install --upgrade pygments
           echo "${HOME}/.local/bin" >> ${GITHUB_PATH}
         
       - name: Build Mkdocs

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -7,7 +7,10 @@ RUN apt update && \
     apt install -y sudo apt-utils bash-completion wget ruby git magic-wormhole \
                    python3 python3-pip python3-setuptools python3-wheel
 
-RUN pip3 install mkdocs mkdocs-material pymdown-extensions
+RUN pip install mkdocs && \
+    wget https://raw.githubusercontent.com/icub-tech-iit/documentation/master/mkdocs.yml && \
+    pip install $(mkdocs get-deps) && \
+    rm mkdocs.yml
 
 RUN gem install yaml
 

--- a/README.md
+++ b/README.md
@@ -47,16 +47,17 @@ Then, install the [Gitpod browser extension](https://www.gitpod.io/docs/browser-
 
 ## 💻 Install the environment yourself
 If you prefer to work on the documentation on your own computer without using Cloud IDEs as described in the previous section,
-you need to install the following software packages:
-* [mkdocs](https://www.mkdocs.org/)
-* [mkdocs-material](https://github.com/squidfunk/mkdocs-material)
-* [mkdocs-material-extensions](https://pypi.org/project/mkdocs-material-extensions/)
-* [PyMdown Extensions](https://facelessuser.github.io/pymdown-extensions/)
+you need to install [**`mkdocs`**](https://www.mkdocs.org/) first.
 
-Once you have installed them, just clone this repo, navigate to it and serve its content with the `mkdocs serve` command:
+Once installed, just clone this repo, navigate to it and install the required dependencies:
 ```console
-git clone https://github.com/icub-tech-iit/documentation
+git clone https://github.com/icub-tech-iit/documentation.git
 cd documentation
+pip install $(mkdocs get-deps)
+```
+
+Finally, serve the content:
+```console
 mkdocs serve
 ```
 
@@ -69,9 +70,12 @@ First of all you need a conda distribution, for example [Miniforge3](https://git
 
 If you already have a conda distribution, just create a new [environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) (for example called `mkdocs-env`) and install in it the require dependencies:
 ```console
+git clone https://github.com/icub-tech-iit/documentation.git
+cd documentation
 conda create -n mkdocs-env
 conda activate mkdocs-env
-conda install --channel conda-forge mkdocs-material mkdocs-material-extensions pymdown-extensions
+conda install --channel conda-forge mkdocs
+conda install --channel conda-forge $(mkdocs get-deps)
 ```
 
 After the installation, whenever you need to test the website just activate the `mkdocs-env` environment and call `mkdocs serve` in the `documentation` directory:

--- a/docs/icub_robot_configuration/devices_configuration/devices_configuration.md
+++ b/docs/icub_robot_configuration/devices_configuration/devices_configuration.md
@@ -24,7 +24,7 @@ The motor control on the iCub robots is managed by three kinds of boards: `EMS4`
 
 One of the major changes, starting from version 3.0, consists of introduction of CONTROLS tag: it allows the user to save in file different PID configurations and he/she can choose which configuration he/she wants to use depending on the experiment he/she wants to run on the robot. To do this, the user writes one or more sections of PID within the file and indicates the selected PID in the "CONTROLS" group.
 
-Anyway, the user must be careful to respect the hardware configuration under use when tuning the PID gains in the control group. The control law is fixed to minimun jerk but the ouput of the PID depends on the HW configuration. Referring to the image above, we have currently [two kinds of HW configurations](../../../icub_wiring/icub2_x/#ethernet-backbone) available on the robot:
+Anyway, the user must be careful to respect the hardware configuration under use when tuning the PID gains in the control group. The control law is fixed to minimun jerk but the ouput of the PID depends on the HW configuration. Referring to the image above, we have currently [two kinds of HW configurations](../../icub_wiring/icub2_x.md#ethernet-backbone) available on the robot:
 
 ![motor_control](./img/motorcontrol.jpg "Motor control on iCub").
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,8 +91,9 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tasklist
   - pymdownx.tilde
-  - markdown.extensions.toc:
-      permalink: true
+
+not_in_nav: |
+  /sw_versioning_table/[0-9]*.md
 
 nav:
   - iCub Tech Docs:


### PR DESCRIPTION
We can use from `mkdocs@v1.5.0`:
- `mkdocs get-deps` to parse `mkdocs.yml` and determine the required extensions.
- rely on `not_in_nav` section to omit files.