### PR TITLE
Fix an incorrect command on icub_microphones.md

### DIFF
--- a/docs/icub_microphones/icub_microphones.md
+++ b/docs/icub_microphones/icub_microphones.md
@@ -38,7 +38,7 @@ If you rely on [`robotology-superbuild`](https://github.com/robotology/robotolog
  We can connect the two modules with the command:
  
  ```
- yarp connect /audioPlayerRecorder/audio:o /audioPlayerWrapper/audio:i tcp_fast
+ yarp connect /audioRecorderWrapper/audio:o /audioPlayerWrapper/audio:i fast_tcp
  ```
  
  The option --start will automatically enable the devices on startup; otherwise, we can start/stop the recording/playback by sending the command on the corresponding RPC ports.


### PR DESCRIPTION
## What changes:

During the maintenance tests of `iCubSingapore01` I find this typo error on [iCub Microphones](https://icub-tech-iit.github.io/documentation/icub_microphones/icub_microphones/?h=micr) page.

This PR fix this incorrect command.

cc @sgiraz 