### PR TITLE
COM-EXP CPU `powersave` vs. `performance` mode

### DIFF
--- a/docs/icub_operating_systems/icubos/installation-from-scratch.md
+++ b/docs/icub_operating_systems/icubos/installation-from-scratch.md
@@ -218,6 +218,9 @@ If you already set the passwordless SSH login, you can skip the password:
 sudo sshfs -o allow_other,IdentityFile=/home/icub/.ssh/id_rsa icub@10.0.0.2:/usr/local/src/robot/ /home/icub/icub-head_fs
 ```
 
+### Enable the CPU `performance` mode
+By default, the CPU is configured in `powersave` mode, which causes critical processes to run somewhat slowly. Therefore, switch the CPU default mode to `performance` by following these [instructions](https://askubuntu.com/questions/929884/how-to-set-performance-instead-of-powersave-as-default).
+
 ## Customize the system
 
 What now you need to do is to customize the installation with your hardware and environment (see the "_Required configuration_" paragraph in [_Networking_](networking.md), [_Bluetooth_](bluetooth.md), [_User Environment_](user-env.md) chapters as well as [_Further Tasks_ chapter](further-tasks.md) )


### PR DESCRIPTION
It turned out that the CPU default mode is `powersave` instead of `performance`.
This PR adds instructions to change it.

@davidelasagna, we'd need to include this change in the next releases of our pre-build images, as @traversaro suggested.