### PR TITLE
Update the stator-rotor calibration with the default value

### DIFF
--- a/docs/icub_robot_calibration/icub3-stator-rotor-autocalibration.md
+++ b/docs/icub_robot_calibration/icub3-stator-rotor-autocalibration.md
@@ -44,6 +44,7 @@ Looking at par64, the rightmost 4 digits are the offset: `0x0079` = `121` degree
 !!!warning
     The 8 leftmost digits (in the example `0xffcc0042`) must be not `0`!<br>
     Otherwise the calibration is failed/not completed. 
+    It should be noted that the default value is `0xffff`.
 
 !!!note
     The joint number is determined by its `2FOC` CAN address, considering that `adr` can be in [1-4]: 

--- a/docs/icub_robot_calibration/icub3-stator-rotor-autocalibration.md
+++ b/docs/icub_robot_calibration/icub3-stator-rotor-autocalibration.md
@@ -41,10 +41,11 @@ Once `yarprobotinterface` is running, check the log messages and look for a `DEB
 
 Looking at par64, the rightmost 4 digits are the offset: `0x0079` = `121` degrees; this is the value to save in the file (see next steps). 
 
+The first `DEBUG` messages have the rightmost 4 digits equal to the default value `0xffff` until the offset is not found. 
+
 !!!warning
     The 8 leftmost digits (in the example `0xffcc0042`) must be not `0`!<br>
     Otherwise the calibration is failed/not completed. 
-    It should be noted that the default value is `0xffff`.
 
 !!!note
     The joint number is determined by its `2FOC` CAN address, considering that `adr` can be in [1-4]: 


### PR DESCRIPTION
In the PR https://github.com/robotology/icub-firmware/pull/466 we changed the default value from 0 to 0xffff because 0 is one possible value for the offset.

cc @MSECode 