### PR TITLE
Fix icub-head compile robotology-superbuild

### DIFF
--- a/docs/sw_installation/icub_head_superbuild.md
+++ b/docs/sw_installation/icub_head_superbuild.md
@@ -42,7 +42,7 @@ directories.
 ## Compile robotology-superbuild
 ~~~sh
 cd /usr/local/src/robot/robotology-superbuild
-mkdir build
+mkdir build && cd build
 cmake -DROBOTOLOGY_USES_GAZEBO:BOOL=OFF -DROBOTOLOGY_ENABLE_ICUB_HEAD:BOOL=ON ..
 make
 ~~~


### PR DESCRIPTION
This PR adds a missing `cd build` in icub-head robotology-superbuild installation:

https://github.com/icub-tech-iit/documentation/blob/8c830ee82ae2ac9115e3a62ffe362323b77ae1a7/docs/sw_installation/icub_head_superbuild.md?plain=1#L42-L47

cc @Nicogene 