### PR TITLE
Fix hyperlinks under ergoCub1_wiring folder

### DIFF
--- a/docs/ergoCub1_wiring/ergoCub1_1.md
+++ b/docs/ergoCub1_wiring/ergoCub1_1.md
@@ -7,17 +7,14 @@ The system architecture of ergoCub1.1 is depicted in the following image:
 
 ### Logic and Harness ergoCub 1.1 Full Robot 
 
-- [ergoCub1.1 Logic_1.1.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Logic_17256_1.1.0.pdf)
-- [ergoCub1.1 Harness_1.1.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Harness_17257_1.1.0.pdf)
+- [ergoCub1.1 S/N:001 Logic_1.1.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Logic_17256_1.1.0.pdf)
+- [ergoCub1.1 S/N:001 Harness_1.1.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Harness_17257_1.1.0.pdf)
+
+- [ergoCub1.1 S/N:002 Logic_1.1.3](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Logic_17256_1.1.3.pdf)
+- [ergoCub1.1 S/N:002 Harness_1.1.3](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Harness_17256_1.1.3.pdf)
 
 ### Motor & Board Placement ergoCub 1.1 
 
-- [ergoCub1.1 Head](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_M%26B_placement_Head.pdf)
-- [ergoCub1.1 Left Leg](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_M%26B_placement_Left_Leg.pdf)
-- [ergoCub1.1 Left Lowerarm](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_M%26B_placement_Left_Lowerarm.pdf)
-- [ergoCub1.1 Left Upperarm](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_M%26B_placement_Left_Upperarm.pdf)
-- [ergoCub1.1 Right Leg](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_M%26B_placement_Right_Leg.pdf)
-- [ergoCub1.1 Right Lowerarm](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_M%26B_placement_Right_Lowerarm.pdf)
-- [ergoCub1.1 Right Upperarm](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_M%26B_placement_Right_Upperarm.pdf)
-- [ergoCub1.1 Torso](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_M%26B_placement_Torso.pdf)
-- [ergoCub1.1 Waist](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_M%26B_placement_Waist.pdf)
+- [ergoCub1.1 S/N:001 rev1.1.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_0_M%26B_placement.pdf)
+- [ergoCub1.1 S/N:002 rev1.1.3](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_3_M%26B_placement.pdf)
+


### PR DESCRIPTION
We've updated links under **ergoCub1_wiring** and also added pdfs of the schematics of `eCub1.1 S/N:002`


cc @pattacini @sgiraz 