### PR TITLE
fix hyperlinks ergoCub1.1 & ergoCub1.2 - wiring folder

### DIFF
--- a/docs/ergoCub1_wiring/ergoCub1_1.md
+++ b/docs/ergoCub1_wiring/ergoCub1_1.md
@@ -10,11 +10,7 @@ The system architecture of ergoCub1.1 is depicted in the following image:
 - [ergoCub1.1 S/N:001 Logic_1.1.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Logic_17256_1.1.0.pdf)
 - [ergoCub1.1 S/N:001 Harness_1.1.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Harness_17257_1.1.0.pdf)
 
-- [ergoCub1.1 S/N:002 Logic_1.1.3](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Logic_17256_1.1.3.pdf)
-- [ergoCub1.1 S/N:002 Harness_1.1.3](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1.1_Harness_17256_1.1.3.pdf)
-
 ### Motor & Board Placement ergoCub 1.1 
 
 - [ergoCub1.1 S/N:001 rev1.1.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_0_M%26B_placement.pdf)
-- [ergoCub1.1 S/N:002 rev1.1.3](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.1/pdf/ergoCub1_1_3_M%26B_placement.pdf)
 

--- a/docs/ergoCub1_wiring/ergoCub1_2.md
+++ b/docs/ergoCub1_wiring/ergoCub1_2.md
@@ -1,0 +1,16 @@
+## ergoCub 1.1 Wiring 
+The system architecture of ergoCub1.1 is depicted in the following image:
+
+<center>
+  <img src ="../img/ergoCub1.1_architecture.png" width=1000>      
+</center>
+
+### Logic and Harness ergoCub 1.2 Full Robot 
+
+- [ergoCub1.2 S/N:002 Logic_1.2.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.2/pdf/ergoCub1.2_Logic_17256_1.2.0.pdf)
+- [ergoCub1.2 S/N:002 Harness_1.2.2](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.2/pdf/ergoCub1.2_Harness_17256_1.2.0.pdf)
+
+### Motor & Board Placement ergoCub 1.1 
+
+- [ergoCub1.2 S/N:002 rev1.2.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.2/pdf/ergoCub1_2_0_M%26B_placement.pdf)
+

--- a/docs/ergoCub1_wiring/ergoCub1_2.md
+++ b/docs/ergoCub1_wiring/ergoCub1_2.md
@@ -1,5 +1,5 @@
-## ergoCub 1.1 Wiring 
-The system architecture of ergoCub1.1 is depicted in the following image:
+## ergoCub 1.2 Wiring 
+The system architecture of ergoCub1.2 is depicted in the following image:
 
 <center>
   <img src ="../img/ergoCub1.1_architecture.png" width=1000>      
@@ -8,9 +8,9 @@ The system architecture of ergoCub1.1 is depicted in the following image:
 ### Logic and Harness ergoCub 1.2 Full Robot 
 
 - [ergoCub1.2 S/N:002 Logic_1.2.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.2/pdf/ergoCub1.2_Logic_17256_1.2.0.pdf)
-- [ergoCub1.2 S/N:002 Harness_1.2.2](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.2/pdf/ergoCub1.2_Harness_17256_1.2.0.pdf)
+- [ergoCub1.2 S/N:002 Harness_1.2.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.2/pdf/ergoCub1.2_Harness_17256_1.2.0.pdf)
 
-### Motor & Board Placement ergoCub 1.1 
+### Motor & Board Placement ergoCub 1.2 
 
 - [ergoCub1.2 S/N:002 rev1.2.0](https://github.com/icub-tech-iit/electronics-wiring-public/blob/master/ergocub1/ergocub1.2/pdf/ergoCub1_2_0_M%26B_placement.pdf)
 


### PR DESCRIPTION
I've updated links under ergoCub1_wiring and I separated the ergoCub1.1 (SN001) and ergoCub1.2 (SN002) pdfs

cc @pattacini 