### PR TITLE
From Gitpod to GH Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,7 @@ RUN gem install yaml
 
 RUN rm -Rf /var/lib/apt/lists/*
 
-RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod && \
+RUN useradd -l -u 33333 -G sudo -md /home/coder -s /bin/bash -p coder coder && \
     sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
 
 EXPOSE 8000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
 	"name": "iCub Tech Documentation",
 	"build": {
-		"dockerfile": "../.gitpod.Dockerfile"
+		"dockerfile": "Dockerfile"
 	},
 	"extensions": [],
 	"forwardPorts": [8000],
-	"remoteUser": "gitpod"
+	"remoteUser": "coder"
 }

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,0 @@
-image:
-  file: .gitpod.Dockerfile
-ports:
-- port: 8000
-  onOpen: notify

--- a/README.md
+++ b/README.md
@@ -21,16 +21,7 @@ This repository is maintained by:
 # ☁ Cloud Workflow
 You can leverage on the following Cloud IDE's to quickly get a testing platform where to try out how the documentation is rendered.
 
-## 🔘 [Gitpod](https://www.gitpod.io)
-First off, sign up for Gitpod using your GitHub credentials. You'll have 50 hours/month of free usage on public and private repositories. Also, remember to visit the [Gitpod Integrations](https://gitpod.io/integrations) to make sure that all GitHub permissions are ticked in.
-
-Then, install the [Gitpod browser extension](https://www.gitpod.io/docs/browser-extension).
-
-| Click to enlarge |
-| :---: |
-| ![](./assets/gitpod.gif) |
-
-## 🔘 [GitHub Codespaces](https://github.com/features/codespaces) (if available)
+## 🔘 [GitHub Codespaces](https://github.com/features/codespaces)
 
 | Click to enlarge |
 | :---: |


### PR DESCRIPTION
This PR refactors the infrastructure to favor Codespaces and remove Gitpod.