### PR TITLE
Update conda instructions to use miniforge and conda instead of mambaforge and mamba

### DIFF
--- a/docs/sw_installation/conda_binaries.md
+++ b/docs/sw_installation/conda_binaries.md
@@ -5,26 +5,24 @@ We provide binary packages for Linux, macOS and Windows of the software containe
 ## Install a conda distribution
 
 If you do not have a conda distribution on your system, we suggest to use the minimal
-[`mambaforge`](https://github.com/conda-forge/miniforge#mambaforge) distribution, that uses `conda-forge` packages by default and installs the [`mamba`](https://github.com/mamba-org/mamba) command by default.
+[`miniforge`](https://github.com/conda-forge/miniforge) distribution, that uses `conda-forge` packages by default.
 
-To install `mambaforge`, please follow the instructions [`install-mambaforge`](https://github.com/robotology/robotology-superbuild/blob/master/doc/install-mambaforge.md) in robotology-superbuild documentation.
-
-Even if you are not using `mambaforge` and you are using instead a different `conda` distribution, to follow the instructions on this document you need to install the `mamba` package in your `base` environment. [`mamba`](https://github.com/mamba-org/mamba) is a re-implementation of some functionalities of the `conda` package manager, that is much faster.
-
+To install `miniforge`, please follow the instructions [`install-miniforge`](https://github.com/robotology/robotology-superbuild/blob/master/doc/install-miniforge.md) in robotology-superbuild documentation.
 
 ## Create an environment
+
 Differently from `apt` and `homebrew`, the `conda` package manager is an `environment`-oriented package manager, meaning that packages are not
 installed in some global location, but rather you install packages in an `environment` (that is just a directory in your filesystem), so that you
 can easily have multiple different environments with different packages installed on your system. To read more about this, check https://docs.conda.io/projects/conda/en/4.6.1/user-guide/tasks/manage-environments.html .
 
 For this reason, to use the robotology conda packages it is suggested to first create a conda environment, and then install in it all the packages you want to use. To create a new environment called `robotologyenv`, execute the following command:
 ~~~
-mamba create -n robotologyenv
+conda create -n robotologyenv
 ~~~
 
 Once you created the `robotologyenv` environment, you can "activate" it for the current terminal (i.e. make sure that the installed packages can be found) by the command:
 ~~~
-mamba activate robotologyenv
+conda activate robotologyenv
 ~~~
 
 !!! note
@@ -40,28 +38,23 @@ mamba activate robotologyenv
 
 Once you are in an activated environment, you can install robotology packages by just running the command:
 ~~~
-mamba install -c conda-forge -c robotology <packagename>
+conda  install -c conda-forge -c robotology <packagename>
 ~~~
 
-The list of available packages is available at https://anaconda.org/robotology/repo .
+Some conda packages of software contained in the `robotology-superbuild` are contained in the `conda-forge` channel, while others in `robotology` channel. 
+When a package is available in both, the `conda-forge` channel contains the most updated version, so always ensure that the `conda-forge` channel as an higher priority w.r.t. to the `robotology` channel.
 
 For example, if you want to install yarp and icub-main, you simple need to install:
 ~~~
-mamba install -c conda-forge -c robotology yarp icub-main
+conda install -c conda-forge -c robotology yarp icub-main
 ~~~
 
-In addition, if you want to simulate the iCub in Gazebo, you should also install `icub-models` and `gazebo-yarp-plugins`:
+In addition, if you want to simulate the iCub in Gazebo Classic, you should also install `icub-models` and `gazebo-yarp-plugins`:
 ~~~
-mamba install -c conda-forge -c robotology gazebo-yarp-plugins icub-models
+conda install -c conda-forge -c robotology gazebo-yarp-plugins icub-models
 ~~~
 
 If you want to develop some C++ code on the top of these libraries, it is recommended to also install the necessary compiler and development tools directly in the same environment:
 ~~~
-mamba install -c conda-forge compilers cmake pkg-config make ninja
-~~~
-
-If you want instead install all the robotology distro just:
-
-~~~
-mamba install -c robotology robotology-distro
+conda install -c conda-forge compilers cmake pkg-config make ninja
 ~~~


### PR DESCRIPTION
Same motivations as in https://github.com/robotology/robotology-superbuild/pull/1653 . 

In a nutshell:
* Since conda 23.10 (released on November 2023), the `libmamba` solver is the default solver (see https://conda.org/blog/2023-11-06-conda-23-10-0-release/), and that should give more and less the same performances of the `mamba` command, without the confusion between `conda` and `mamba` for new users.
* `mambaforge` is deprecated since July 2024 and will be removed in January 2025 (see https://github.com/conda-forge/miniforge/commit/362b0c4aa285d8af9cafc59b0b1eaa4fa6fb0dad). As now `miniforge` also contains `mamba`, users can just install `miniforge` in place of `mambaforge` and get exactly the same functionality.

So this PR changes all the instances of `mambaforge` to `miniforge` and of `mamba` to `conda`.

Other changes:
* Do not suggest the use of `robotology-distro` to install all packages. The `robotology-distro` is just a package that constraint the version of packages to be the one of the corresponding distro, but does not install all packages, for example `conda create -n testenv robotology-distro==2024.08.*` dones not install yarp, while `conda create -n testenv robotology-distro==2024.08.* yarp` ensures that `yarp==3.9.0` is installed. However, for a long time the package was not built (see https://anaconda.org/robotology/robotology-distro) due to CI problems on releases, so I prefer not to document it as a supported feature (if people want to install version corresponding to a distro, they can manually check https://icub-tech-iit.github.io/documentation/sw_versioning_table/#table, even if it is not super user friendly).
* Explain that some packages are available on `conda-forge` and other on `robotology`. As of October 2024, all packages mentioned in the guide (`yarp`, `icub-main`, `gazebo-yarp-plugins`, `icub-models`) are actually available on conda-forge, however better continue to mention `robotology` in the instructions in case users try to install some package available only there.