### PR TITLE
Add documentation to setup the screen of the ergocub-head

### DIFF
--- a/docs/icub_operating_systems/icubos/jetpack.md
+++ b/docs/icub_operating_systems/icubos/jetpack.md
@@ -143,3 +143,4 @@ After successfully flashing your NVIDIA board by following the dedicated procedu
 - [Install jtop](./install-jtop.md)
 - [Install CMake (only for Ubuntu 20.04)](./install-cmake.md)
 - [Setup Orin NX for FRAMOS-IMX415 (only for `iCub head v2.10`)](./setup-framos-imx415.md)
+- [Setup ergoCub screen (only for `ergocub-head`)](./setup-ergocub-screen.md)

--- a/docs/icub_operating_systems/icubos/setup-ergocub-screen.md
+++ b/docs/icub_operating_systems/icubos/setup-ergocub-screen.md
@@ -1,0 +1,67 @@
+# Setup ergoCub Screen
+
+!!! info
+    This procedure should be performed after the [JetPack installation](./jetpack.md) has been completed.
+
+When you start the ergoCub head for the first time, the screen will display a desktop showing the NVIDIA logo. While this is generally fine, it requires the user to manually run the [`ergoCubEmotions`](https://github.com/icub-tech-iit/ergocub-software/tree/master/src/modules/ergoCubEmotions) module. This procedure allows you to hide all bars on the desktop and set the wallpaper to one of the images stored in the [expressions folder](https://github.com/icub-tech-iit/ergocub-software/tree/14599254440686b8a373e1635f046a6821ddee78/src/modules/ergoCubEmotions/expressions/images).
+
+---
+
+## Hide the Ubuntu Bar
+
+This guide is based on instructions from [here](https://askubuntu.com/questions/1264686/is-there-a-way-to-hide-ubuntu-dock-and-top-bar-using-terminal). 
+
+1. Create a script in the `ergocub-head` home directory:
+
+    ```bash
+    #!/bin/bash
+
+    status1=$(gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval string:'Main.panel.actor.visible;')
+    status2=$(gdbus call --session --dest org.gnome.Shell.Extensions --object-path /org/gnome/Shell/Extensions --method org.gnome.Shell.Extensions.GetExtensionInfo ubuntu-dock@ubuntu.com | grep "'state': <2.0>" >/dev/null && echo "OFF" || echo "ON")
+
+    if [ "$status1" == "(true, 'false')" ]; then
+      gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval 'Main.panel.actor.show();'
+    else
+      gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval 'Main.panel.actor.hide();'
+    fi
+
+    if [ "$status2" == "ON" ]; then
+      gdbus call --session --dest org.gnome.Shell.Extensions --object-path /org/gnome/Shell/Extensions --method org.gnome.Shell.Extensions.DisableExtension ubuntu-dock@ubuntu.com
+    else
+      gdbus call --session --dest org.gnome.Shell.Extensions --object-path /org/gnome/Shell/Extensions --method org.gnome.Shell.Extensions.EnableExtension ubuntu-dock@ubuntu.com
+    fi
+    ```
+
+2. Run the script to toggle hiding or showing the bars.
+
+---
+
+## Change the Desktop Wallpaper
+
+1. SSH into the `ergocub-head` and use the following command to set the wallpaper:
+
+    ```bash
+    gsettings set org.gnome.desktop.background picture-uri <uri-of-the-wallpaper>
+    ```
+
+2. If [ergocub-software](https://github.com/icub-tech-iit/ergocub-software) is installed via the robotology-superbuild, you can use this command:
+
+    ```bash
+    gsettings set org.gnome.desktop.background picture-uri file:///usr/local/src/robot/robotology-superbuild/src/ergocub-software/src/modules/ergoCubEmotions/expressions/images/exp_img_1.png
+    ```
+
+---
+
+## Clean the Icons from the Desktop
+
+1. Create a folder in the home directory to store the desktop files:
+
+    ```bash
+    mkdir ~/all_desktop
+    ```
+
+2. Move all files from the desktop to the newly created folder:
+
+    ```bash
+    mv ~/Desktop/* ~/all_desktop/
+    ```

--- a/docs/icub_operating_systems/icubos/setup-ergocub-screen.md
+++ b/docs/icub_operating_systems/icubos/setup-ergocub-screen.md
@@ -9,7 +9,7 @@ When you start the ergoCub head for the first time, the screen will display a de
 
 ## Hide the Ubuntu Bar
 
-This guide is based on instructions from [here](https://askubuntu.com/questions/1264686/is-there-a-way-to-hide-ubuntu-dock-and-top-bar-using-terminal). 
+This guide is based on these [instructions](https://askubuntu.com/questions/1264686/is-there-a-way-to-hide-ubuntu-dock-and-top-bar-using-terminal). 
 
 1. Create a script in the `ergocub-head` home directory:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -258,6 +258,8 @@ nav:
           - Install jtop: icub_operating_systems/icubos/install-jtop.md
           - Install CMake (only for Ubuntu 20.04): icub_operating_systems/icubos/install-cmake.md
           - Setup for FRAMOS-IMX415 (only for iCub head v2.10): icub_operating_systems/icubos/setup-framos-imx415.md
+          - Setup ergoCub screen (only for ergocub-head): icub_operating_systems/icubos/setup-ergocub-screen.md
+
       - iCub Setup Multiple Robots:
         - Summary: icub_setup_multiple_robots/index.md
         - How to use two iCub robots in gazebo simulation: icub_setup_multiple_robots/two_robots_simulation.md


### PR DESCRIPTION
This pull request includes updates to the documentation related to the `ergocub-head` setup process. The most important changes involve adding a new guide for setting up the ergoCub screen and updating the navigation to include this new guide.

Documentation updates:

* [`docs/icub_operating_systems/icubos/jetpack.md`](diffhunk://#diff-a02cdf58276b80d0bf376a87fc7789a940041cc2295c2fee9afbc67e207047a6R146): Added a new link to the "Setup ergoCub screen" guide.
* [`docs/icub_operating_systems/icubos/setup-ergocub-screen.md`](diffhunk://#diff-74d5d699e529ef60d91a361da1c0562aa54d8b1a69041e0fb45066004618687aR1-R67): Created a comprehensive guide for setting up the ergoCub screen, including instructions for hiding the Ubuntu bar, changing the desktop wallpaper, and cleaning the icons from the desktop.

This is the outcome of https://github.com/ami-iit/lab-events-demos/issues/332#issuecomment-2438245878


cc @S-Dafarra 