### PR TITLE
FW docs: Clarify the steps require to activate a MDK community license

### DIFF
--- a/docs/icub_firmware/fw_toolchain/installing_keil.md
+++ b/docs/icub_firmware/fw_toolchain/installing_keil.md
@@ -25,11 +25,11 @@ Run the installer that you downloaded on the previous step.
 
 ### Configuring your license
 
-To be able to use MDK-Community, you need a valid license. Go to https://keil.arm.com/mdk-community to receive a product serial number and learn how to convert it into a license.
+To be able to use MDK-Community, you need a valid license. Go to https://keil.arm.com/mdk-community to activate a Community (non-commercial) license.
 
 !!! note
 
-    Use in commercial applications is not permitted
+    Use in commercial applications of the Community (non-commercial) license is not permitted
 
 ## Configuring iCub-firmware
 


### PR DESCRIPTION
As of early 2025, the steps required to activate a MDK Community (non-commercial) license do not require to receive a product serial number but just to list a MDK Community License server, so I (hopefully) clarified the wording.