### PR TITLE
Update ergoCub1 wrist range of motion

### DIFF
--- a/docs/ergoCub1/ergoCub1-joints.md
+++ b/docs/ergoCub1/ergoCub1-joints.md
@@ -188,8 +188,8 @@ The technical specifications of the electro-mechanical components for the joints
 | Speed Reducer        | Spur Gearhead, Reduction 324:1 (integrated with motor) |
 | Transmission         | Linkages (variable reduction)                          |
 | Joint Encoder        | FAP board with finger absolute position sensor         |
-| Range of Motion (HW) | +6/+20 (degrees)                                       |
-| Range of Motion (SW) | +7/+18 (degrees)                                       | 
+| Range of Motion (HW) | +0/+15 (degrees)                                       |
+| Range of Motion (SW) | +0/+15 (degrees)                                       | 
 
 ### Joint 10 - index finger open & close 
 

--- a/docs/ergoCub1/ergoCub1-joints.md
+++ b/docs/ergoCub1/ergoCub1-joints.md
@@ -131,8 +131,8 @@ The technical specifications of the electro-mechanical components for the joints
 | Speed Reducer        | Planetary Gearhead, Faulhaber 22 GPT, Reduction 196:1 (integrated with motor) |
 | Transmission         | Belt drive (2:1)                                                              |
 | Joint Encoder        | AEA board with MA730 (absolute angle encoder)                                 |
-| Range of Motion (HW) | -62/+52 (degrees)                                                             |
-| Range of Motion (SW) | -60/+50 (degrees)                                                             |
+| Range of Motion (HW) | -20/+30 (degrees)                                                             |
+| Range of Motion (SW) | -20/+30 (degrees)                                                             |
 
 !!! note 
     all wrist joints are coupled into a co-axial spherical parallel mechanism
@@ -146,8 +146,8 @@ The technical specifications of the electro-mechanical components for the joints
 | Speed Reducer        | Planetary Gearhead, Faulhaber 22 GPT, Reduction 196:1 (integrated with motor) |
 | Transmission         | Belt drive (2:1)                                                              |
 | Joint Encoder        | AEA board with MA730 (absolute angle encoder)                                 |
-| Range of Motion (HW) | -32/+32 (degrees)                                                             |
-| Range of Motion (SW) | -30/+30 (degrees)                                                             |
+| Range of Motion (HW) | -20/+20 (degrees)                                                             |
+| Range of Motion (SW) | -20/+20 (degrees)                                                             |
 
 !!! note 
     all wrist joints are coupled into a co-axial spherical parallel mechanism


### PR DESCRIPTION
The PR updates:
- The range of motion of the wrist roll and wrist pitch.
- The range of motion of the index ab/adduction.

Associated documentation:
- Wrist: [robot configuration file](https://github.com/robotology/robots-configuration/blob/3be388a8bbb7e1b588657ec7ac24feb8509a1c33/ergoCubSN002/hardware/mechanicals/left_arm-eb31-j4_6-mec.xml#L22)
- Index: CAD model
![image](https://github.com/user-attachments/assets/cd3f8087-85a5-429b-96f0-b62bdbcdce74)
