### PR TITLE
Update ergoCub1 Hip Roll RoM

### DIFF
--- a/docs/ergoCub1/ergoCub1-joints.md
+++ b/docs/ergoCub1/ergoCub1-joints.md
@@ -286,7 +286,7 @@ The technical specifications of the electro-mechanical components for the joints
 | Transmission         | Belt drive (1:1)                                                                                                   | 
 | Speed Reducer        | Harmonic Drive CSD-20-160-2UH, Reduction 160:1                                                                     |
 | Joint Encoder        | AMO board with iC-MU (absolute magnetic off-axis encoder) + Magnetic wheel (PWB_103839), 64/63 pole pairs, OD 50.7 |
-| Range of Motion (HW) | -35/+111 (degrees)                                                                                                 |
+| Range of Motion (HW) | -20/+111 (degrees)                                                                                                 |
 | Range of Motion (SW) | -15/+108 (degrees)                                                                                                 |
 
 ### Joint 2 - hip yaw


### PR DESCRIPTION
I have reviewed the range of motion (RoM) of the Hip Pitch joint and updated it following a verification of both the robot and the CAD model.  

The highlighted areas below indicate the hard stop locations (thanks @AntonioConsilvio).  

![sd](https://github.com/user-attachments/assets/dd9ffc03-6ef3-4024-ba7d-4358199e925b)

![image](https://github.com/user-attachments/assets/32d98228-1eac-459b-8011-4b3a77a1ee5f)
