### PR TITLE
Fix syntax for some centered images

### DIFF
--- a/docs/upgrade_kits/ankle_for_stairs/support.md
+++ b/docs/upgrade_kits/ankle_for_stairs/support.md
@@ -39,13 +39,13 @@ We are going to replace iCub feet plates in order to increase the step length an
 
 - At this point we are going to separate cover and foot plate removing these screws
 
-    | <center> ![imagine view](img/cover.jpg) </center> |
+    | ![](img/cover.jpg) |
     | :-----------------------------------------------: |
     |       how to separate foot plate from cover       |
 
 - Now we can follow the procedure back mounting the cover on the new foot plate
 
-    | <center> ![imagine view](img/new_foot.jpg) </center> |
+    | ![](img/new_foot.jpg) |
     | :--------------------------------------------------: |
     |                  the new foot plate                  |
 

--- a/docs/upgrade_kits/backpack/support.md
+++ b/docs/upgrade_kits/backpack/support.md
@@ -6,7 +6,10 @@
 ## Upgrade Kit
 
 This upgrade kit is meant to update the iCub backpack with new accomodation for the COM-Express and new design for its upper cover.
-<center> ![](img/iCubBackpack.jpg) </center>
+
+<figure markdown="span">
+    ![](img/iCubBackpack.jpg)
+</figure>
 
 | | |
 | :---: | :---: |
@@ -22,7 +25,9 @@ This upgrade kit is meant to update the iCub backpack with new accomodation for 
 
 ## Content material  MKIT_010
 
-<center> ![](img/COMExpressBackpack.jpg) </center>
+<figure markdown="span">
+    ![](img/COMExpressBackpack.jpg)
+</figure>
 
 | Alias                         | Description                                                                 | Code  | Rev | Qty |
 |-------------------------------|-----------------------------------------------------------------------------|-------|-----|-----|
@@ -43,7 +48,6 @@ This upgrade kit is meant to update the iCub backpack with new accomodation for 
 | 🔘 Click to download the PDF |
 | :---: |
 
-
 ## Content material  EKIT_010
 |  Pieces |     Alias    |    Rev    |  Description       |  Code Wgst |
 |   :---: |    :-----------:      |     :---: |   :---:   |   :---:   |
@@ -54,7 +58,8 @@ This upgrade kit is meant to update the iCub backpack with new accomodation for 
 
 Draft Logic schematic
 
-|
+| 🔘 Click to download the PDF |
+| :-------------------------: |
 
 ## Assembly instruction
 

--- a/docs/upgrade_kits/differential_neck_pulley/support.md
+++ b/docs/upgrade_kits/differential_neck_pulley/support.md
@@ -40,20 +40,20 @@ Here are the instructions for replacing the left pulley.
 - First of all you need to remove tendons from the neck. [Neck's tendons replacement](../../icub_tendons/neck.md)
 - Remove the green highlighted assembly loosening the screws indicated by arrows
 
-    | <center> ![imagine view](img/belt_ass.PNG) </center> |
+    | ![](img/belt_ass.PNG) |
     | :-----------------------------------------------------------: |
     |  tbd |
 
 - Untight the screw shown in left picture to extract the whole motor assembly shown on the right.
 
-    | <center> ![imagine view](img/mot_ass.PNG) </center> |  <center> ![imagine view](img/mot_ass_alone.PNG) </center> |
+    | ![](img/mot_ass.PNG) | ![](img/mot_ass_alone.PNG) |
     | :----: | :----: |
     | The whole neck | The motor assembly |
 
 - Gently remove pulley's assembly as on left picture and remove the flex spline from the pulley untightening the screw shown on rigth.
 
 
-    | <center> ![imagine view](img/pulley_ass.PNG) </center> |  <center> ![imagine view](img/flex.PNG) </center> |
+    | ![](img/pulley_ass.PNG) | ![](img/flex.PNG) |
     | :----: | :----: |
     | pulley assembly |  the screw to remove    |
 

--- a/docs/upgrade_kits/eyes/support.md
+++ b/docs/upgrade_kits/eyes/support.md
@@ -28,7 +28,7 @@ We are going to replace parts in the eyes tilt assembly, there are some prelimin
 * we need to unplug and remove the whole boards' frame.
 
 
-    | <center> ![imagine view](img/no_cover.JPG) </center> | <center> ![imagine view](img/no_frame.JPG) </center> |
+    | ![](img/no_cover.JPG) | ![](img/no_frame.JPG) |
     | :--------------------------------------------------: | :--------------------------------------------------: |
     |                    without covers                    |                without boards' frame                 |
 
@@ -38,27 +38,27 @@ We are going to replace parts in the eyes tilt assembly, there are some prelimin
 
     We are going to replace the 4 parts here in picture.
     
-| <center> ![](img/4thng.JPG) </center> |
+| ![](img/4thng.JPG) |
 | :-----------------------------------------------------------: |
 |  Brackets unmounting |
     
     
   We need to remove eye's assembly from the head unlocking two cross recessed screws
 
-| <center> ![imagine view](img/remove.JPG) </center> | <center> ![imagine view](img/eye_group.JPG) </center> |
+| ![](img/remove.JPG) | ![](img/eye_group.JPG) |
 | :--------------------------------------------------: | :--------------------------------------------------: |
 |                    the screws to remove                   |                eye's group                 |
 
 Unmount the groupand replace the old case with the new one
 
-| <center> ![imagine view](img/OLD.JPG) </center> | <center> ![imagine view](img/new.JPG) </center> |
+| ![](img/OLD.JPG) | ![](img/new.JPG) |
 | :--------------------------------------------------: | :--------------------------------------------------: |
 |                    old one                   |                new one                 |
 
 
 While mounting the motoreducer group checl if it moves at the correct amount of current, if not try to slightly release these screws
 
- | <center> ![imagine view](img/screws.JPG) </center> |
+ | ![](img/screws.JPG) |
  | :-----------------------------------------------------------: |
  |  motoreducer group |
 
@@ -67,7 +67,7 @@ Releasing the grub screws (blue arrows) we can remove the pins (yellow arrows) a
 - First of all you need to remove tendons from the neck, 
 - Remove the green highlighted assembly loosening the screws indicated by arrows
 
-| <center>  ![imagine view](img/brackets.JPG) </center> |
+| ![](img/brackets.JPG) |
 | :-----------------------------------------------------------: |
 |  Brackets unmounting |
 

--- a/docs/upgrade_kits/hands/support.md
+++ b/docs/upgrade_kits/hands/support.md
@@ -28,18 +28,30 @@ First of all you need to know that you will be in a situation where you will hav
 Once this is done the first piece to be mounted will be the rc_IIT_011_g_016 or the rc_IIT_011_g_017 (right or left hand) as shown in the video. All this because you will find yourself in the condition in which you will have to pass the piece between the cables (tendons) that move the thumb.
 **This explanation is the same for both hands**
 
-<center> ![imagine view](gif/SUPPORT_RIGHT_TOP.gif) </center>
+<figure markdown="span">
+    ![](gif/SUPPORT_RIGHT_TOP.gif)
+</figure>
 
 ##Exploding: 
 Reference Right hand
 
-<center> ![imagine view](img/esploso3.JPG) ![imagine view](img/esploso4.JPG)  </center>
+<figure markdown="span">
+    ![](img/esploso3.JPG)
+</figure>
+
+<figure markdown="span">
+    ![](img/esploso4.JPG)
+</figure>
 
 Assemble upgrade support Mais and FTC 
 
-<center> ![imagine view](img/Montaggio1.JPG) </center>
+<figure markdown="span">
+    ![](img/Montaggio1.JPG)
+</figure>
 
-<center> ![imagine view](img/Montaggio2.JPG) </center>
+<figure markdown="span">
+    ![](img/Montaggio2.JPG)
+</figure>
 
 ##Assembly sequence##
 <div width="100%">

--- a/docs/upgrade_kits/head_4k/support.md
+++ b/docs/upgrade_kits/head_4k/support.md
@@ -8,7 +8,9 @@
 
 This upgrade kit is meant to update the head with new eyes composed by high-resolution cameras, bigger FOV lenses, new GPU, new accomodation for the COM-Express in the backpack, new design for the upper cover of the backpack.
 
-<center> ![](img/iCubHead4K_Backpack.jpg) </center>
+<figure markdown="span">
+    ![](img/iCubHead4K_Backpack.jpg)
+</figure>
 
 | | |
 | :---: | :---: |
@@ -24,7 +26,9 @@ This upgrade kit is meant to update the head with new eyes composed by high-reso
 
 ## Content material  MKIT_009
 
-<center> ![](img/Head4k_parts.jpg) </center>
+<figure markdown="span">
+    ![](img/Head4k_parts.jpg)
+</figure>
 
 | Alias                          | Description                                                                      | Code  | Rev | Qty |
 |--------------------------------|----------------------------------------------------------------------------------|-------|-----|-----|

--- a/docs/upgrade_kits/index.md
+++ b/docs/upgrade_kits/index.md
@@ -23,3 +23,7 @@
 
 ### 🔘 KIT_009 iCub Upgrade Kit: Head with 4K Cameras
 [iCub new head UpKit](./head_4k/support.md)
+
+### 🔘 KIT_010 iCub Backpack with COM-Express
+[iCub Backpack UpKit](./backpack/support.md)
+

--- a/docs/upgrade_kits/torso_capacitors/support.md
+++ b/docs/upgrade_kits/torso_capacitors/support.md
@@ -19,11 +19,26 @@
 ## Assembly instructions
 
 Make sure the 4 capacitors (front and back) are accessible (has a view). For the removal and subsequent reassembly of the parts that obstruct (backpack unit), refer to the specific manual .<br>
-<center> ![imagine view](img/8.JPG) </center>
-<center> ![imagine view](img/9.JPG) </center>
+
+<figure markdown="span">
+    ![](img/8.JPG)
+</figure>
+
+<figure markdown="span">
+    ![imagine view](img/9.JPG)
+</figure>
      
 **Assembly sequence** :<br>
 *Perform the assembly sequence as indicated in the image, keep in mind that the sequence is the same for all 4 support (Front and rear).*<br>
-<center> ![imagine view](img/13.JPG) </center>
 
-<center> ![imagine view](img/16.JPG) ![imagine view](img/17.JPG)  </center>
+<figure markdown="span">
+    ![](img/13.JPG)
+</figure>
+
+<figure markdown="span">
+    ![](img/16.JPG)
+</figure>
+
+<figure markdown="span">
+    ![](img/17.JPG)
+</figure>

--- a/docs/upgrade_kits/upperarm_cover_icub2_5/support.md
+++ b/docs/upgrade_kits/upperarm_cover_icub2_5/support.md
@@ -39,6 +39,7 @@
 |   1     |    10273 	 |     	 | 	iCub 2.5, subassembly - Left Upperarm Skin Harness, wiring materials |10273 |
 
 !!! note "note"
+
     [link to harness schematics](https://github.com/icub-tech-iit/electronics-wiring-public/tree/master/icub-upgrade-kits/kit_004/14767%20-%20iCub%20Upperarms%20fix%20skin%20breaking%20(wiring%20parts)) 
 
 ## Content material  EKIT_004 
@@ -48,37 +49,53 @@
 |  1 |   13476     |        | 	iCubSkin 2.5, Left Upper Arm Skin, RUGGED Electronic boards  |    13476  |
 
 !!! note "note"
+
     [link to logic schematics](https://github.com/icub-tech-iit/electronics-wiring-public/tree/master/icub-upgrade-kits/kit_004/14768%20-%20iCub%20Upperarms%20fix%20skin%20breaking%20(electronics))
 
 ## Historical review:
 In previous revisions of the covers, the mini cards were organized in the shape of hexagons. This largely caused the skin patch PCB to flex and break, because the patches took the high curvature of the cover (see image).
 
-<center> ![imagine view](img/12.PNG) </center>
+<figure markdown="span">
+    ![](img/12.PNG)
+</figure>
 
 To solve this problem, we reduced the number of PCBs by arranging a strip with 5 PCBs (skin patch) on the flat surface of the cover. (see image)
 
-<center> ![imagine view](img/10.PNG) </center>
-
+<figure markdown="span">
+    ![](img/10.PNG)
+</figure>
 
 ## Assembly instruction.
 
 First of all, it must be said that the electronic part of the upper arm covers is already supplied, that is, the MTB4 cards and the hexagon shape (skin) are mounted, glued and connected together.
 Before starting assembly, check the orientation of the covers.<br>
 
-<center> ![imagine view](img/8.PNG) </center>
+<figure markdown="span">
+    ![](img/8.PNG)
+</figure>
 
 **Assembly sequence** :<br>
 
 *Perform the assembly sequence as shown in the image, keep in mind that the sequence is the same for both upper arms (Right and left)*<br>
 
 - First step push the cover (RC_IIT_017_P_023) inwards so as to align the attachment holes, both positions (TOP and BOTTOM), as can be seen in the image.
--<center> ![imagine view](img/2.PNG) </center>
+ 
+<figure markdown="span">
+    ![](img/2.PNG)
+</figure>
 
 - Second and third step, fix the cover using the respective screws as shown in the image. This applies to both positions TOP and BOTTOM.
 
-<center> ![imagine view](img/3.PNG) </center>
+<figure markdown="span">
+    ![](img/3.PNG)
+</figure>
 
 - Fourth step, close the covers of the upper arm by pushing the Lover cover inwards in order to align the attachment holes. After that fix the covers with the respective lives as shown in the pictures.  This applies to both positions TOP and BOTTOM.
 
-<center> ![imagine view](img/4.PNG) </center>
-<center> ![imagine view](img/5.PNG) </center>
+<figure markdown="span">
+    ![](img/4.PNG)
+</figure>
+
+<figure markdown="span">
+    ![](img/5.PNG)
+</figure>


### PR DESCRIPTION
The html syntax `<center>` works only with html
We can use `<figure>` for native markdown, instead.

cc @Nicogene 